### PR TITLE
Add local CLI for offline processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ This project provides a sample Photoshop UXP plugin and a Python backend for aut
    ```
    The server listens on `http://localhost:5000/process`.
 
+### Local Command-Line Usage
+To run the correction entirely offline on a local image, use the provided CLI:
+
+```bash
+python photoshop_underwater_plugin_bundle/flask_api/local_cli.py input.jpg output.jpg
+```
+
+Add `--advanced` to enable the more advanced Sea‑Thru model. This mode does not
+contact the Photoshop API and simply writes the corrected file to the specified
+output path.
+
 ## UXP Plugin Setup
 1. Install the [UXP Developer Tool](https://developer.adobe.com/photoshop/uxp/guides/uxp-developer-tools/).
 2. In the tool, click **Add Plugin** and select the `photoshop_underwater_plugin_bundle/uxp_plugin` folder.

--- a/photoshop_underwater_plugin_bundle/flask_api/local_cli.py
+++ b/photoshop_underwater_plugin_bundle/flask_api/local_cli.py
@@ -1,0 +1,23 @@
+import argparse
+import os
+
+from main import process_image
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run underwater correction locally")
+    parser.add_argument("image_path", help="Path to the input image")
+    parser.add_argument("output_path", help="Path for the corrected output image")
+    parser.add_argument("--advanced", action="store_true", help="Use advanced Sea-Thru")
+    args = parser.parse_args()
+
+    if args.advanced:
+        os.environ["ADVANCED_SEATHRU"] = "1"
+
+    result = process_image(image_path=args.image_path, output_path=args.output_path)
+    print(f"Saved corrected image to {args.output_path}")
+    print(result["adjustments"])
+
+
+if __name__ == "__main__":
+    main()

--- a/photoshop_underwater_plugin_bundle/flask_api/main.py
+++ b/photoshop_underwater_plugin_bundle/flask_api/main.py
@@ -5,6 +5,7 @@ from depth_estimation import estimate_depth
 from image_analysis import analyze_image
 from photoshop_api import submit_photoshop_job
 from sea_thru import apply_sea_thru
+import shutil
 
 def download_image(url, local_path):
     response = requests.get(url)
@@ -13,11 +14,25 @@ def download_image(url, local_path):
         f.write(response.content)
 
 
-def process_image(image_url: str = None, output_url: str = None, image_file=None):
+def process_image(
+    image_url: str | None = None,
+    output_url: str | None = None,
+    image_file=None,
+    *,
+    image_path: str | None = None,
+    output_path: str | None = None,
+):
+    """Process an image from a URL, uploaded file, or local path.
+
+    ``output_url`` triggers a Photoshop API job, while ``output_path`` simply
+    writes the corrected file locally. One of these must be provided.
+    """
     if image_file is not None:
         local_path = os.path.join('images', 'input', image_file.filename or 'upload.jpg')
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
         image_file.save(local_path)
+    elif image_path is not None:
+        local_path = image_path
     else:
         local_path = os.path.join('images', 'input', 'input.jpg')
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
@@ -33,7 +48,13 @@ def process_image(image_url: str = None, output_url: str = None, image_file=None
         'analysis': analysis,
     }
 
-    submit_photoshop_job(corrected_path, output_url, adjustments)
+    if output_url:
+        submit_photoshop_job(corrected_path, output_url, adjustments)
+    elif output_path:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        shutil.copy(corrected_path, output_path)
+    else:
+        raise ValueError('Either output_url or output_path must be provided')
 
     return {
         'status': 'submitted',


### PR DESCRIPTION
## Summary
- implement `local_cli.py` for running the algorithm on local files
- extend `process_image` to accept local paths and save outputs
- update README with usage instructions
- adjust tests to use lightweight stubs and cover CLI invocation

## Testing
- `python -m py_compile $(find photoshop_underwater_plugin_bundle -name '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646f350f5083229e30ed5a23ee56e5